### PR TITLE
Finishes Log In Mechanism

### DIFF
--- a/app/home/urls.py
+++ b/app/home/urls.py
@@ -3,6 +3,6 @@ from django.conf.urls import url
 from app.home.views import LoginView, IndexView
 
 urlpatterns = [
-    url(r'^$', IndexView.as_view(template_name='react.html')),
-    url(r'^login$', LoginView.as_view(template_name='react.html')),
+    url(r'^$', IndexView.as_view(template_name='react.html'), name="index"),
+    url(r'^login$', LoginView.as_view(template_name='react.html'), name="login"),
 ]

--- a/app/home/views.py
+++ b/app/home/views.py
@@ -1,3 +1,4 @@
+from django.contrib.auth.mixins import LoginRequiredMixin
 from django.urls import reverse
 from django.views.generic import TemplateView
 
@@ -8,11 +9,11 @@ class LoginView(TemplateView):
         ctx = super(LoginView, self).get_context_data(**kwargs)
         ctx['title'] = "login to dankyrank"
         ctx['component'] = 'Login'
-        ctx['initialState'] = {"login_link": reverse("social:begin", args=["google-oauth2"])}
+        ctx['initialState'] = {"login_link": reverse("social:begin", args=["spotify"])}
         return ctx
 
 
-class IndexView(TemplateView):
+class IndexView(LoginRequiredMixin, TemplateView):
 
     def get_context_data(self, **kwargs):
         ctx = super(IndexView, self).get_context_data(**kwargs)

--- a/settings.py
+++ b/settings.py
@@ -1,6 +1,7 @@
 import os
 
 import dj_database_url
+from django.urls import reverse_lazy
 
 APP_NAME = 'dankyrank'
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -26,12 +27,15 @@ WSGI_APPLICATION = 'wsgi.application'
 
 # APP AND MIDDLEWARE SETTINGS
 
-SOCIAL_AUTH_AUTHENTICATION_BACKENDS = (
+AUTHENTICATION_BACKENDS = [
     'social_core.backends.spotify.SpotifyOAuth2',
     'django.contrib.auth.backends.ModelBackend',
-)
+]
 
 SOCIAL_AUTH_POSTGRES_JSONFIELD = True
+SOCIAL_AUTH_URL_NAMESPACE = 'social'
+LOGIN_URL = reverse_lazy('login')
+LOGIN_REDIRECT_URL = reverse_lazy('index')
 
 DJANGO_APPS = [
     'django.contrib.admin',
@@ -113,6 +117,8 @@ TEMPLATES = [
                 'django.template.context_processors.static',
                 'django.template.context_processors.tz',
                 'django.contrib.messages.context_processors.messages',
+                'social_django.context_processors.backends',
+                'social_django.context_processors.login_redirect',
             ],
         },
     },

--- a/urls.py
+++ b/urls.py
@@ -5,7 +5,7 @@ from django.urls import include
 import app.home.urls
 
 urlpatterns = [
-    url(r'^admin/', admin.site.urls),
     url(r'', include(app.home.urls)),
-    url('', include('social_django.urls', namespace='social')),
+    url(r'^admin/', admin.site.urls),
+    url(r'^social/', include('social_django.urls', namespace='social')),
 ]


### PR DESCRIPTION
Now that our redirect URLs are correct on Spotify, this change causes
the index view to correctly require login, redirect the user to the
login URL, then properly handle the post-login redirect to the index
page. There's no log out button right now but you can clear your cookies
for 127.0.0.1:8000 and you'll get the same effect for now.